### PR TITLE
Fix three.js dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "camera-controls": "^2.8.3",
-        "oh-vue-icons": "^1.0.0-rc3",
-        "three": "^0.162.0",
-        "three-viewport-gizmo": "^0.1.0"
+        "oh-vue-icons": "^1.0.0-rc3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",
@@ -24,6 +22,9 @@
         "vite-plugin-dts": "^3.7.3",
         "vitepress": "^1.4.1",
         "vue": "^3.5.12"
+      },
+      "peerDependencies": {
+        "three": "^0.162.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -3033,16 +3034,8 @@
     "node_modules/three": {
       "version": "0.162.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
-      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ=="
-    },
-    "node_modules/three-viewport-gizmo": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/three-viewport-gizmo/-/three-viewport-gizmo-0.1.0.tgz",
-      "integrity": "sha512-/IjrQtcy9d7KsxA7tnPzP1bFGOqYj/Gbt2zxBnb050FIUyBJtVB3gNTzso5jD1N74YXRxKz3mxC6LbxF4zqNKg==",
-      "dependencies": {
-        "camera-controls": "^2.8.3",
-        "three": "^0.162.0"
-      }
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
+      "peer": true
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -5407,16 +5400,8 @@
     "three": {
       "version": "0.162.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
-      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ=="
-    },
-    "three-viewport-gizmo": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/three-viewport-gizmo/-/three-viewport-gizmo-0.1.0.tgz",
-      "integrity": "sha512-/IjrQtcy9d7KsxA7tnPzP1bFGOqYj/Gbt2zxBnb050FIUyBJtVB3gNTzso5jD1N74YXRxKz3mxC6LbxF4zqNKg==",
-      "requires": {
-        "camera-controls": "^2.8.3",
-        "three": "^0.162.0"
-      }
+      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
+      "peer": true
     },
     "trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "vitepress": "^1.4.1",
     "vue": "^3.5.12"
   },
+  "peerDependencies": {
+    "three": "^0.162.0"
+  },
   "dependencies": {
     "camera-controls": "^2.8.3",
-    "oh-vue-icons": "^1.0.0-rc3",
-    "three": "^0.162.0",
-    "three-viewport-gizmo": "^0.1.0"
+    "oh-vue-icons": "^1.0.0-rc3"
   },
   "keywords": [
     "three.js",


### PR DESCRIPTION
Hello! First of all, thanks a lot for making this library—it's incredibly useful for web 3D editing.

When I tried to install `three-viewport-gizmo` from NPM for use in my own project, I discovered a couple of dependency issues:

- Regardless of the version of three.js I specified in my `package.json`, `three-viewport-gizmo` always uses its own independent version of three.js under `node_modules/three-viewport-gizmo/node_modules/three`, instead of directly using my existing `node_modules/three`. This causes the infamous "Multiple instances of Three.js being imported" warning.

- `three-viewport-gizmo` has a dependency on itself, and on a very old version—0.1.0. This creates a third dependency on three.js that appears something like: `node_modules/three-viewport-gizmo/node_modules/three-viewport-gizmo/node_modules/three` I believe this is an unintentional mistake.

I noticed that the samples collection included in the repo (a great resource to have, by the way—kudos!) all use CDN import maps, which work fine because you excluded THREE in the Vite build process. So, you only run into this issue when installing from NPM and using a bundler setup.

What I did here:

- Removed the dependency on itself.

- Made three.js a peer dependency. Since `three-viewport-gizmo` is mostly used in tandem with three.js (as opposed to being used as a standalone package), this ensures that `three-viewport-gizmo` will look for and use the existing three.js version in the project.

Cheers!
Felix Z
