### PR TITLE
Added font size to GizmoOptions and axesMap

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -83,6 +83,8 @@ export type GizmoOptions = {
     family?: string;
     /** Font weight for axis labels */
     weight?: string | number;
+    /** Font size in pixels for axis labels */
+    size?: number;
   };
 
   /**

--- a/lib/utils/axesMap.ts
+++ b/lib/utils/axesMap.ts
@@ -173,6 +173,9 @@ export const axesMap = (options: GizmoOptionsFallback, offset: number = 2) => {
       ? Math.sqrt(Math.pow(resolution * 0.7, 2) / 2)
       : resolution;
     let fontSize = square;
+    if (options.font.size > 0) {
+      fontSize = options.font.size;
+    }
     let textWidth = 0;
     let textHeight = 0;
 


### PR DESCRIPTION
**Changes**
- Added `size`  property to `GizmoOptions.font`
- Added validation to use the `GizmoOptions.font.size` value if it is greater than 0, when setting the `fontSize`.

**Why**
- In my language one of the `label`'s was a little too large for my liking and I simply wanted the freedom to adjust it. Decided to create a PR in case this is interesting to anybody else :)